### PR TITLE
chore: Update `socket.js` in the quickstart overlay

### DIFF
--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -376,7 +376,7 @@ export default WebSocketManager;
  * @property {string} gameplay.hits.grade.current
  * @property {string} gameplay.hits.grade.maxThisPlay
  * @property {number} gameplay.hits.unstableRate
- * @property {} gameplay.hits.hitErrorArray
+ * @property {number[]} gameplay.hits.hitErrorArray
  * @property {object} gameplay.pp
  * @property {number} gameplay.pp.current
  * @property {number} gameplay.pp.fc
@@ -410,7 +410,7 @@ export default WebSocketManager;
  * @property {number} gameplay.leaderboard.ourplayer.team
  * @property {number} gameplay.leaderboard.ourplayer.position
  * @property {number} gameplay.leaderboard.ourplayer.isPassing
- * @property {} gameplay.leaderboard.slots
+ * @property {object[]} gameplay.leaderboard.slots
  * @property {boolean} gameplay._isReplayUiHidden
  * @property {object} resultsScreen
  * @property {number} resultsScreen.0
@@ -451,7 +451,7 @@ export default WebSocketManager;
  * @property {object} tourney.manager.bools
  * @property {boolean} tourney.manager.bools.scoreVisible
  * @property {boolean} tourney.manager.bools.starsVisible
- * @property {} tourney.manager.chat
+ * @property {object[]} tourney.manager.chat
  * @property {object} tourney.manager.gameplay
  * @property {object} tourney.manager.gameplay.score
  * @property {number} tourney.manager.gameplay.score.left
@@ -490,7 +490,7 @@ export default WebSocketManager;
  * @property {string} tourney.ipcClients.gameplay.hits.grade.current
  * @property {string} tourney.ipcClients.gameplay.hits.grade.maxThisPlay
  * @property {number} tourney.ipcClients.gameplay.hits.unstableRate
- * @property {} tourney.ipcClients.gameplay.hits.hitErrorArray
+ * @property {number[]} tourney.ipcClients.gameplay.hits.hitErrorArray
  * @property {object} tourney.ipcClients.gameplay.mods
  * @property {number} tourney.ipcClients.gameplay.mods.num
  * @property {string} tourney.ipcClients.gameplay.mods.str

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -293,7 +293,7 @@ export default WebSocketManager;
  * @property {object} menu.mainMenu
  * @property {number} menu.mainMenu.bassDensity
  * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23} menu.state
- * @property {0 | 1 | 2 | 3 } menu.gameMode
+ * @property {0 | 1 | 2 | 3} menu.gameMode
  * @property {0 | 1} menu.isChatEnabled
  * @property {object} menu.bm
  * @property {object} menu.bm.time
@@ -361,7 +361,7 @@ export default WebSocketManager;
  * @property {number[]} menu.pp.strainsAll.series.data
  * @property {number[]} menu.pp.strainsAll.xaxis
  * @property {object} gameplay
- * @property {0 | 1 | 2 | 3 } gameplay.gameMode
+ * @property {0 | 1 | 2 | 3} gameplay.gameMode
  * @property {string} gameplay.name
  * @property {number} gameplay.score
  * @property {number} gameplay.accuracy
@@ -456,7 +456,7 @@ export default WebSocketManager;
  * @property {number} userProfile.id
  * @property {number} userProfile.level
  * @property {number} userProfile.playCount
- * @property {0 | 1 | 2 | 3 } userProfile.playMode
+ * @property {0 | 1 | 2 | 3} userProfile.playMode
  * @property {number} userProfile.rank
  * @property {number} userProfile.countryCode
  * @property {number} userProfile.performancePoints
@@ -629,7 +629,7 @@ export default WebSocketManager;
  * @property {number} profile.id
  * @property {string} profile.name
  * @property {object} profile.mode
- * @property {0 | 1 | 2 | 3 } profile.mode.number
+ * @property {0 | 1 | 2 | 3} profile.mode.number
  * @property {'osu' | 'taiko' | 'fruits' | 'mania'} profile.mode.name
  * @property {number} profile.rankedScore
  * @property {number} profile.level
@@ -655,7 +655,7 @@ export default WebSocketManager;
  * @property {number} beatmap.id
  * @property {number} beatmap.set
  * @property {object} beatmap.mode
- * @property {0 | 1 | 2 | 3 } beatmap.mode.number
+ * @property {0 | 1 | 2 | 3} beatmap.mode.number
  * @property {'osu' | 'taiko' | 'fruits' | 'mania'} beatmap.mode.name
  * @property {string} beatmap.artist
  * @property {string} beatmap.artistUnicode
@@ -703,7 +703,7 @@ export default WebSocketManager;
  * @property {object} play
  * @property {string} play.playerName
  * @property {object} play.mode
- * @property {0 | 1 | 2 | 3 } play.mode.number
+ * @property {0 | 1 | 2 | 3} play.mode.number
  * @property {'osu' | 'taiko' | 'fruits' | 'mania'} play.mode.name
  * @property {number} play.score
  * @property {number} play.accuracy
@@ -803,7 +803,7 @@ export default WebSocketManager;
  * @property {number} resultsScreen.scoreId
  * @property {string} resultsScreen.playerName
  * @property {object} resultsScreen.mode
- * @property {0 | 1 | 2 | 3 } resultsScreen.mode.number
+ * @property {0 | 1 | 2 | 3} resultsScreen.mode.number
  * @property {'osu' | 'taiko' | 'fruits' | 'mania'} resultsScreen.mode.name
  * @property {number} resultsScreen.score
  * @property {number} resultsScreen.accuracy
@@ -917,7 +917,7 @@ export default WebSocketManager;
  * @property {object} tourney.clients.play
  * @property {string} tourney.clients.play.playerName
  * @property {object} tourney.clients.play.mode
- * @property {0 | 1 | 2 | 3 } tourney.clients.play.mode.number
+ * @property {0 | 1 | 2 | 3} tourney.clients.play.mode.number
  * @property {'osu' | 'taiko' | 'fruits' | 'mania'} tourney.clients.play.mode.name
  * @property {number} tourney.clients.play.score
  * @property {number} tourney.clients.play.accuracy

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -554,8 +554,11 @@ export default WebSocketManager;
  * @property {number} settings.resolution.heightFullscreen
  * @property {object} settings.client
  * @property {boolean} settings.client.updateAvailable
- * @property {0 | 1 | 2 | 3} settings.client.branch
- * @property {string} settings.client.version
+ * @property {0 | 1 | 2 | 3} settings.client.branch - 0: Cutting Edge
+ *                                                  - 1: Stable
+ *                                                  - 2: Beta
+ *                                                  - 3: Stable (Fallback)
+ * @property {string} settings.client.version The full build version, e.g. `b20241029cuttingedge`
  * @property {object} settings.scoreMeter
  * @property {object} settings.scoreMeter.type
  * @property {0 | 1 | 2} settings.scoreMeter.type.number
@@ -578,7 +581,7 @@ export default WebSocketManager;
  * @property {'artist' | 'bpm' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'title'} settings.sort.name
  * @property {object} settings.group
  * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19} settings.group.number
- * @property {'none' | 'artist' | 'bPM' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'myMaps' | 'search' | 'show_All' | 'title' | 'lastPlayed' | 'onlineFavourites' | 'maniaKeys' | 'mode' | 'collection' | 'rankedStatus'} settings.group.name Note: `search` and `show_All` share the same number `12`
+ * @property {'none' | 'artist' | 'bPM' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'myMaps' | 'search' | 'show_All' | 'title' | 'lastPlayed' | 'onlineFavourites' | 'maniaKeys' | 'mode' | 'collection' | 'rankedStatus'} settings.group.name Note: `search` and `show_All` share the same number - `12`
  * @property {object} settings.skin
  * @property {boolean} settings.skin.useDefaultSkinInEditor
  * @property {boolean} settings.skin.ignoreBeatmapSkins

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -87,8 +87,8 @@ class WebSocketManager {
 
 
   /**
-   * Connects to keyOverlay socket api.
-   * @param {(data: WEBSOCKET_V2_KEYS) => void} callback - The function to handle received messages.
+   * Connects to tosu precise socket api.
+   * @param {(data: WEBSOCKET_V2_PRECISE) => void} callback - The function to handle received messages.
    * @param {Filters[]} filters
    */
   api_v2_precise(callback, filters) {
@@ -976,7 +976,7 @@ export default WebSocketManager;
 
 
 
-/** @typedef {object} WEBSOCKET_V2_KEYS
+/** @typedef {object} WEBSOCKET_V2_PRECISE
  * @property {number} currentTime
  * @property {object} keys
  * @property {object} keys.k1

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -282,7 +282,7 @@ export default WebSocketManager;
 
 
 /** @typedef {object} WEBSOCKET_V1
- * @property {string} client
+ * @property {'stable' | 'lazer'} client
  * @property {object} settings
  * @property {boolean} settings.showInterface
  * @property {object} settings.folders
@@ -292,9 +292,9 @@ export default WebSocketManager;
  * @property {object} menu
  * @property {object} menu.mainMenu
  * @property {number} menu.mainMenu.bassDensity
- * @property {number} menu.state
- * @property {number} menu.gameMode
- * @property {number} menu.isChatEnabled
+ * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23} menu.state
+ * @property {0 | 1 | 2 | 3 } menu.gameMode
+ * @property {0 | 1} menu.isChatEnabled
  * @property {object} menu.bm
  * @property {object} menu.bm.time
  * @property {number} menu.bm.time.firstObj
@@ -304,7 +304,7 @@ export default WebSocketManager;
  * @property {number} menu.bm.id
  * @property {number} menu.bm.set
  * @property {string} menu.bm.md5
- * @property {number} menu.bm.rankedStatus
+ * @property {0 | 1 | 2 | 4 | 5 | 6 | 7} menu.bm.rankedStatus
  * @property {object} menu.bm.metadata
  * @property {string} menu.bm.metadata.artist
  * @property {string} menu.bm.metadata.artistOriginal
@@ -357,11 +357,11 @@ export default WebSocketManager;
  * @property {number[]} menu.pp.strains
  * @property {object} menu.pp.strainsAll
  * @property {object[]} menu.pp.strainsAll.series
- * @property {string} menu.pp.strainsAll.series.name
+ * @property {'aim' | 'aimNoSliders' | 'flashlight' | 'speed' | 'color' | 'rhythm' | 'stamina' | 'movement' | 'strains'} menu.pp.strainsAll.series.name
  * @property {number[]} menu.pp.strainsAll.series.data
  * @property {number[]} menu.pp.strainsAll.xaxis
  * @property {object} gameplay
- * @property {number} gameplay.gameMode
+ * @property {0 | 1 | 2 | 3 } gameplay.gameMode
  * @property {string} gameplay.name
  * @property {number} gameplay.score
  * @property {number} gameplay.accuracy
@@ -380,8 +380,8 @@ export default WebSocketManager;
  * @property {number} gameplay.hits.katu
  * @property {number} gameplay.hits.sliderBreaks
  * @property {object} gameplay.hits.grade
- * @property {string} gameplay.hits.grade.current
- * @property {string} gameplay.hits.grade.maxThisPlay
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} gameplay.hits.grade.current
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} gameplay.hits.grade.maxThisPlay
  * @property {number} gameplay.hits.unstableRate
  * @property {number[]} gameplay.hits.hitErrorArray
  * @property {object} gameplay.pp
@@ -436,7 +436,7 @@ export default WebSocketManager;
  * @property {number} resultsScreen.50
  * @property {number} resultsScreen.100
  * @property {number} resultsScreen.300
- * @property {number} resultsScreen.mode
+ * @property {0 | 1 | 2 | 3} resultsScreen.mode
  * @property {string} resultsScreen.name
  * @property {number} resultsScreen.score
  * @property {number} resultsScreen.accuracy
@@ -446,21 +446,21 @@ export default WebSocketManager;
  * @property {string} resultsScreen.mods.str
  * @property {number} resultsScreen.geki
  * @property {number} resultsScreen.katu
- * @property {string} resultsScreen.grade
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} resultsScreen.grade
  * @property {string} resultsScreen.createdAt
  * @property {object} userProfile
- * @property {number} userProfile.rawLoginStatus
+ * @property {0 | 256 | 257 | 65537 | 65793} userProfile.rawLoginStatus
  * @property {string} userProfile.name
  * @property {number} userProfile.accuracy
  * @property {number} userProfile.rankedScore
  * @property {number} userProfile.id
  * @property {number} userProfile.level
  * @property {number} userProfile.playCount
- * @property {number} userProfile.playMode
+ * @property {0 | 1 | 2 | 3 } userProfile.playMode
  * @property {number} userProfile.rank
  * @property {number} userProfile.countryCode
  * @property {number} userProfile.performancePoints
- * @property {number} userProfile.rawBanchoStatus
+ * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13} userProfile.rawBanchoStatus
  * @property {string} userProfile.backgroundColour
  * @property {object} tourney
  * @property {object} tourney.manager
@@ -496,7 +496,7 @@ export default WebSocketManager;
  * @property {number} tourney.ipcClients.spectating.globalRank
  * @property {number} tourney.ipcClients.spectating.totalPP
  * @property {object} tourney.ipcClients.gameplay
- * @property {number} tourney.ipcClients.gameplay.gameMode
+ * @property {0 | 1 | 2 | 3} tourney.ipcClients.gameplay.gameMode
  * @property {string} tourney.ipcClients.gameplay.name
  * @property {number} tourney.ipcClients.gameplay.score
  * @property {number} tourney.ipcClients.gameplay.accuracy
@@ -515,8 +515,8 @@ export default WebSocketManager;
  * @property {number} tourney.ipcClients.gameplay.hits.katu
  * @property {number} tourney.ipcClients.gameplay.hits.sliderBreaks
  * @property {object} tourney.ipcClients.gameplay.hits.grade
- * @property {string} tourney.ipcClients.gameplay.hits.grade.current
- * @property {string} tourney.ipcClients.gameplay.hits.grade.maxThisPlay
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.ipcClients.gameplay.hits.grade.current
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.ipcClients.gameplay.hits.grade.maxThisPlay
  * @property {number} tourney.ipcClients.gameplay.hits.unstableRate
  * @property {number[]} tourney.ipcClients.gameplay.hits.hitErrorArray
  * @property {object} tourney.ipcClients.gameplay.mods

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -625,7 +625,7 @@ export default WebSocketManager;
  * @property {'reconnecting' | 'guest' | 'recieving_data' | 'disconnected' | 'connected'} profile.userStatus.name
  * @property {object} profile.banchoStatus
  * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13} profile.banchoStatus.number
- * @property {'idle' | 'afk' | 'playing' | 'editing' | 'modding' | 'multiplayer' | 'watching | 'unknown' | 'testing' | 'submitting' | 'paused' | 'lobby' | 'multiplaying' | 'osuDirect'} profile.banchoStatus.name
+ * @property {'idle' | 'afk' | 'playing' | 'editing' | 'modding' | 'multiplayer' | 'watching' | 'unknown' | 'testing' | 'submitting' | 'paused' | 'lobby' | 'multiplaying' | 'osuDirect'} profile.banchoStatus.name
  * @property {number} profile.id
  * @property {string} profile.name
  * @property {object} profile.mode

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -376,8 +376,8 @@ export default WebSocketManager;
  * @property {number} gameplay.hits.50
  * @property {number} gameplay.hits.100
  * @property {number} gameplay.hits.300
- * @property {number} gameplay.hits.geki
- * @property {number} gameplay.hits.katu
+ * @property {number} gameplay.hits.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} gameplay.hits.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {number} gameplay.hits.sliderBreaks
  * @property {object} gameplay.hits.grade
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} gameplay.hits.grade.current
@@ -444,8 +444,8 @@ export default WebSocketManager;
  * @property {object} resultsScreen.mods
  * @property {number} resultsScreen.mods.num
  * @property {string} resultsScreen.mods.str
- * @property {number} resultsScreen.geki
- * @property {number} resultsScreen.katu
+ * @property {number} resultsScreen.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} resultsScreen.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} resultsScreen.grade
  * @property {string} resultsScreen.createdAt
  * @property {object} userProfile
@@ -511,8 +511,8 @@ export default WebSocketManager;
  * @property {number} tourney.ipcClients.gameplay.hits.50
  * @property {number} tourney.ipcClients.gameplay.hits.100
  * @property {number} tourney.ipcClients.gameplay.hits.300
- * @property {number} tourney.ipcClients.gameplay.hits.geki
- * @property {number} tourney.ipcClients.gameplay.hits.katu
+ * @property {number} tourney.ipcClients.gameplay.hits.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} tourney.ipcClients.gameplay.hits.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {number} tourney.ipcClients.gameplay.hits.sliderBreaks
  * @property {object} tourney.ipcClients.gameplay.hits.grade
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.ipcClients.gameplay.hits.grade.current
@@ -581,7 +581,7 @@ export default WebSocketManager;
  * @property {'artist' | 'bpm' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'title'} settings.sort.name
  * @property {object} settings.group
  * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19} settings.group.number
- * @property {'none' | 'artist' | 'bPM' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'myMaps' | 'search' | 'show_All' | 'title' | 'lastPlayed' | 'onlineFavourites' | 'maniaKeys' | 'mode' | 'collection' | 'rankedStatus'} settings.group.name
+ * @property {'none' | 'artist' | 'bPM' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'myMaps' | 'search' | 'show_All' | 'title' | 'lastPlayed' | 'onlineFavourites' | 'maniaKeys' | 'mode' | 'collection' | 'rankedStatus'} settings.group.name Note: `search` and `show_All` share the same number `12`
  * @property {object} settings.skin
  * @property {boolean} settings.skin.useDefaultSkinInEditor
  * @property {boolean} settings.skin.ignoreBeatmapSkins
@@ -666,15 +666,15 @@ export default WebSocketManager;
  * @property {object} beatmap.stats
  * @property {object} beatmap.stats.stars
  * @property {number} beatmap.stats.stars.live
- * @property {number} [beatmap.stats.stars.aim]
- * @property {number} [beatmap.stats.stars.speed]
- * @property {number} [beatmap.stats.stars.flashlight]
- * @property {number} [beatmap.stats.stars.sliderFactor]
- * @property {number} [beatmap.stats.stars.stamina]
- * @property {number} [beatmap.stats.stars.rhythm]
- * @property {number} [beatmap.stats.stars.color]
- * @property {number} [beatmap.stats.stars.peak]
- * @property {number} [beatmap.stats.stars.hitWindow]
+ * @property {number} [beatmap.stats.stars.aim] This is available only in the osu! ruleset
+ * @property {number} [beatmap.stats.stars.speed] This is available only in the osu! ruleset
+ * @property {number} [beatmap.stats.stars.flashlight] This is available only in the osu! ruleset
+ * @property {number} [beatmap.stats.stars.sliderFactor] This is available only in the osu! ruleset
+ * @property {number} [beatmap.stats.stars.stamina] This is available only in the osu!taiko ruleset
+ * @property {number} [beatmap.stats.stars.rhythm] This is available only in the osu!taiko ruleset
+ * @property {number} [beatmap.stats.stars.color] This is available only in the osu!taiko ruleset
+ * @property {number} [beatmap.stats.stars.peak] This is available only in the osu!taiko ruleset
+ * @property {number} [beatmap.stats.stars.hitWindow] 300's hit window; this is available only in the osu!mania ruleset
  * @property {number} beatmap.stats.stars.total
  * @property {object} beatmap.stats.ar
  * @property {number} beatmap.stats.ar.original
@@ -715,11 +715,11 @@ export default WebSocketManager;
  * @property {number} play.hits.50
  * @property {number} play.hits.100
  * @property {number} play.hits.300
- * @property {number} play.hits.geki
- * @property {number} play.hits.katu
+ * @property {number} play.hits.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} play.hits.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {number} play.hits.sliderBreaks
- * @property {number} play.hits.sliderEndHits
- * @property {number} play.hits.sliderTickHits
+ * @property {number} play.hits.sliderEndHits This is populated only when playing osu!(lazer)
+ * @property {number} play.hits.sliderTickHits This is populated only when playing osu!(lazer)
  * @property {number[]} play.hitErrorArray
  * @property {object} play.combo
  * @property {number} play.combo.current
@@ -730,7 +730,7 @@ export default WebSocketManager;
  * @property {string} play.mods.name
  * @property {object[]} play.mods.array
  * @property {string} play.mods.array.acronym
- * @property {object} [play.mods.array.settings]
+ * @property {object} [play.mods.array.settings] This exists only when playing osu!(lazer)
  * @property {number} play.mods.rate
  * @property {object} play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} play.rank.current
@@ -767,8 +767,8 @@ export default WebSocketManager;
  * @property {number} leaderboard.hits.50
  * @property {number} leaderboard.hits.100
  * @property {number} leaderboard.hits.300
- * @property {number} leaderboard.hits.geki
- * @property {number} leaderboard.hits.katu
+ * @property {number} leaderboard.hits.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} leaderboard.hits.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {object} leaderboard.combo
  * @property {number} leaderboard.combo.current
  * @property {number} leaderboard.combo.max
@@ -812,17 +812,17 @@ export default WebSocketManager;
  * @property {number} resultsScreen.hits.50
  * @property {number} resultsScreen.hits.100
  * @property {number} resultsScreen.hits.300
- * @property {number} resultsScreen.hits.geki
- * @property {number} resultsScreen.hits.katu
- * @property {number} resultsScreen.hits.sliderEndHits
- * @property {number} resultsScreen.hits.sliderTickHits
+ * @property {number} resultsScreen.hits.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} resultsScreen.hits.katu This is also used as the 200's count in the osu!mania ruleset
+ * @property {number} resultsScreen.hits.sliderEndHits This is populated only when playing osu!(lazer)
+ * @property {number} resultsScreen.hits.sliderTickHits This is populated only when playing osu!(lazer)
  * @property {object} resultsScreen.mods
  * @property {string} resultsScreen.mods.checksum
  * @property {number} resultsScreen.mods.number
  * @property {string} resultsScreen.mods.name
  * @property {object[]} resultsScreen.mods.array
  * @property {string} resultsScreen.mods.array.acronym
- * @property {object} [resultsScreen.mods.array.settings]
+ * @property {object} [resultsScreen.mods.array.settings] This exists only when playing osu!(lazer)
  * @property {number} resultsScreen.mods.rate
  * @property {number} resultsScreen.maxCombo
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} resultsScreen.rank
@@ -880,15 +880,15 @@ export default WebSocketManager;
  * @property {object} tourney.clients.beatmap.stats
  * @property {object} tourney.clients.beatmap.stats.stars
  * @property {number} tourney.clients.beatmap.stats.stars.live
- * @property {number} [tourney.clients.beatmap.stats.stars.aim]
- * @property {number} [tourney.clients.beatmap.stats.stars.speed]
- * @property {number} [tourney.clients.beatmap.stats.stars.flashlight]
- * @property {number} [tourney.clients.beatmap.stats.stars.sliderFactor]
- * @property {number} [tourney.clients.beatmap.stats.stars.stamina]
- * @property {number} [tourney.clients.beatmap.stats.stars.rhythm]
- * @property {number} [tourney.clients.beatmap.stats.stars.color]
- * @property {number} [tourney.clients.beatmap.stats.stars.peak]
- * @property {number} [tourney.clients.beatmap.stats.stars.hitWindow]
+ * @property {number} [tourney.clients.beatmap.stats.stars.aim] This is available only in the osu! ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.speed] This is available only in the osu! ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.flashlight] This is available only in the osu! ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.sliderFactor] This is available only in the osu! ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.stamina] This is available only in the osu!taiko ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.rhythm] This is available only in the osu!taiko ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.color] This is available only in the osu!taiko ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.peak] This is available only in the osu!taiko ruleset
+ * @property {number} [tourney.clients.beatmap.stats.stars.hitWindow] 300's hit window; this is available only in the osu!mania ruleset
  * @property {number} tourney.clients.beatmap.stats.stars.total
  * @property {object} tourney.clients.beatmap.stats.ar
  * @property {number} tourney.clients.beatmap.stats.ar.original
@@ -929,11 +929,11 @@ export default WebSocketManager;
  * @property {number} tourney.clients.play.hits.50
  * @property {number} tourney.clients.play.hits.100
  * @property {number} tourney.clients.play.hits.300
- * @property {number} tourney.clients.play.hits.geki
- * @property {number} tourney.clients.play.hits.katu
+ * @property {number} tourney.clients.play.hits.geki This is also used as the 320's count in the osu!mania ruleset
+ * @property {number} tourney.clients.play.hits.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {number} tourney.clients.play.hits.sliderBreaks
- * @property {number} tourney.clients.play.hits.sliderEndHits
- * @property {number} tourney.clients.play.hits.sliderTickHits
+ * @property {number} tourney.clients.play.hits.sliderEndHits This is populated only when playing osu!(lazer)
+ * @property {number} tourney.clients.play.hits.sliderTickHits This is populated only when playing osu!(lazer)
  * @property {number[]} tourney.clients.play.hitErrorArray
  * @property {object} tourney.clients.play.mods
  * @property {number} tourney.clients.play.mods.number
@@ -947,7 +947,7 @@ export default WebSocketManager;
  * @property {string} tourney.clients.play.mods.name
  * @property {object[]} tourney.clients.play.mods.array
  * @property {string} tourney.clients.play.mods.array.acronym
- * @property {object} [play.mods.array.settings]
+ * @property {object} [play.mods.array.settings] This exists only when playing osu!(lazer)
  * @property {number} tourney.clients.play.mods.rate
  * @property {object} tourney.clients.play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.clients.play.rank.current

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -9,7 +9,7 @@ class WebSocketManager {
     this.createConnection = this.createConnection.bind(this);
 
     /**
-     * @type {{ [key: string]: WebSocket }} - asd;
+     * @type {{ [key: string]: WebSocket }} asd;
      */
     this.sockets = {};
   }
@@ -68,7 +68,7 @@ class WebSocketManager {
 
   /**
    * Connects to gosu compatible socket api.
-   * @param {(data: WEBSOCKET_V1) => void} callback - The function to handle received messages.
+   * @param {(data: WEBSOCKET_V1) => void} callback The function to handle received messages.
    * @param {Filters[]} filters
    */
   api_v1(callback, filters) {
@@ -78,7 +78,7 @@ class WebSocketManager {
 
   /**
    * Connects to tosu advanced socket api.
-   * @param {(data: WEBSOCKET_V2) => void} callback - The function to handle received messages.
+   * @param {(data: WEBSOCKET_V2) => void} callback The function to handle received messages.
    * @param {Filters[]} filters
    */
   api_v2(callback, filters) {
@@ -88,7 +88,7 @@ class WebSocketManager {
 
   /**
    * Connects to tosu precise socket api.
-   * @param {(data: WEBSOCKET_V2_PRECISE) => void} callback - The function to handle received messages.
+   * @param {(data: WEBSOCKET_V2_PRECISE) => void} callback The function to handle received messages.
    * @param {Filters[]} filters
    */
   api_v2_precise(callback, filters) {
@@ -131,7 +131,7 @@ class WebSocketManager {
 
   /**
    * Get beatmap **.osu** file (local)
-   * @param {string} file_path - Path to a file **beatmap_folder_name/osu_file_name.osu**
+   * @param {string} file_path Path to a file **beatmap_folder_name/osu_file_name.osu**
    * @returns {string | { error: string }}
    */
   async getBeatmapOsuFile(file_path) {
@@ -162,7 +162,7 @@ class WebSocketManager {
 
   /**
    * Connects to message
-   * @param {(data: { command: string, message: any }) => void} callback - The function to handle received messages.
+   * @param {(data: { command: string, message: any }) => void} callback The function to handle received messages.
    */
   commands(callback) {
     this.createConnection(`/websocket/commands`, callback);
@@ -229,19 +229,19 @@ export default WebSocketManager;
 
 
 /** @typedef {object} CALCULATE_PP
- * @property {string} path - Path to .osu file. Example: C:/osu/Songs/beatmap/file.osu
- * @property {number} mode - Osu = 0, Taiko = 1, Catch = 2, Mania = 3
- * @property {number} mods - Mods id. Example: 64 - DT
- * @property {number} acc - Accuracy % from 0 to 100
- * @property {number} nGeki - Amount of Geki (300g / MAX)
- * @property {number} nKatu - Amount of Katu (100k / 200)
- * @property {number} n300 - Amount of 300
- * @property {number} n100 - Amount of 100
- * @property {number} n50 - Amount of 50
- * @property {number} nMisses - Amount of Misses
- * @property {number} combo - combo
- * @property {number} passedObjects - Sum of nGeki, nKatu, n300, n100, n50, nMisses
- * @property {number} clockRate - Map rate number. Example: 1.5 = DT
+ * @property {string} path Path to .osu file. Example: C:/osu/Songs/beatmap/file.osu
+ * @property {number} mode Osu = 0, Taiko = 1, Catch = 2, Mania = 3
+ * @property {number} mods Mods id. Example: 64 - DT
+ * @property {number} acc Accuracy % from 0 to 100
+ * @property {number} nGeki Amount of Geki (300g / MAX)
+ * @property {number} nKatu Amount of Katu (100k / 200)
+ * @property {number} n300 Amount of 300
+ * @property {number} n100 Amount of 100
+ * @property {number} n50 Amount of 50
+ * @property {number} nMisses Amount of Misses
+ * @property {number} combo combo
+ * @property {number} passedObjects Sum of nGeki, nKatu, n300, n100, n50, nMisses
+ * @property {number} clockRate Map rate number. Example: 1.5 = DT
  */
 
 

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -514,9 +514,6 @@ export default WebSocketManager;
  * @property {number} tourney.ipcClients.gameplay.hits.geki This is also used as the 320's count in the osu!mania ruleset
  * @property {number} tourney.ipcClients.gameplay.hits.katu This is also used as the 200's count in the osu!mania ruleset
  * @property {number} tourney.ipcClients.gameplay.hits.sliderBreaks
- * @property {object} tourney.ipcClients.gameplay.hits.grade
- * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.ipcClients.gameplay.hits.grade.current
- * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.ipcClients.gameplay.hits.grade.maxThisPlay
  * @property {number} tourney.ipcClients.gameplay.hits.unstableRate
  * @property {number[]} tourney.ipcClients.gameplay.hits.hitErrorArray
  * @property {object} tourney.ipcClients.gameplay.mods
@@ -935,9 +932,6 @@ export default WebSocketManager;
  * @property {number} tourney.clients.play.hits.sliderEndHits This is populated only when playing osu!(lazer)
  * @property {number} tourney.clients.play.hits.sliderTickHits This is populated only when playing osu!(lazer)
  * @property {number[]} tourney.clients.play.hitErrorArray
- * @property {object} tourney.clients.play.mods
- * @property {number} tourney.clients.play.mods.number
- * @property {string} tourney.clients.play.mods.name
  * @property {object} tourney.clients.play.combo
  * @property {number} tourney.clients.play.combo.current
  * @property {number} tourney.clients.play.combo.max

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -558,7 +558,7 @@ export default WebSocketManager;
  * @property {object} settings.client
  * @property {boolean} settings.client.updateAvailable
  * @property {0 | 1 | 2 | 3} settings.client.branch
- * @property {'cuttingEdge' | 'stable' | 'beta' | 'fallback'} settings.client.version
+ * @property {string} settings.client.version
  * @property {object} settings.scoreMeter
  * @property {object} settings.scoreMeter.type
  * @property {0 | 1 | 2} settings.scoreMeter.type.number

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -527,6 +527,7 @@ export default WebSocketManager;
 
 
 /** @typedef {object} WEBSOCKET_V2
+ * @property {string} client
  * @property {object} state
  * @property {number} state.number
  * @property {string} state.name
@@ -629,6 +630,7 @@ export default WebSocketManager;
  * @property {string} profile.name
  * @property {object} profile.mode
  * @property {number} profile.mode.number
+ * @property {string} profile.mode.name
  * @property {number} profile.rankedScore
  * @property {number} profile.level
  * @property {number} profile.accuracy
@@ -652,15 +654,15 @@ export default WebSocketManager;
  * @property {string} beatmap.checksum
  * @property {number} beatmap.id
  * @property {number} beatmap.set
+ * @property {object} beatmap.mode
+ * @property {number} beatmap.mode.number
+ * @property {string} beatmap.mode.name
  * @property {string} beatmap.artist
  * @property {string} beatmap.artistUnicode
  * @property {string} beatmap.title
  * @property {string} beatmap.titleUnicode
  * @property {string} beatmap.mapper
  * @property {string} beatmap.version
- * @property {object} beatmap.mode
- * @property {number} beatmap.mode.number
- * @property {string} beatmap.mode.name
  * @property {object} beatmap.stats
  * @property {object} beatmap.stats.stars
  * @property {number} beatmap.stats.stars.live
@@ -668,6 +670,11 @@ export default WebSocketManager;
  * @property {number} beatmap.stats.stars.speed
  * @property {number} beatmap.stats.stars.flashlight
  * @property {number} beatmap.stats.stars.sliderFactor
+ * @property {number} beatmap.stats.stars.stamina
+ * @property {number} beatmap.stats.stars.rhythm
+ * @property {number} beatmap.stats.stars.color
+ * @property {number} beatmap.stats.stars.peak
+ * @property {number} beatmap.stats.stars.hitWindow
  * @property {number} beatmap.stats.stars.total
  * @property {object} beatmap.stats.ar
  * @property {number} beatmap.stats.ar.original
@@ -711,13 +718,20 @@ export default WebSocketManager;
  * @property {number} play.hits.geki
  * @property {number} play.hits.katu
  * @property {number} play.hits.sliderBreaks
+ * @property {number} play.hits.sliderEndHits
+ * @property {number} play.hits.sliderTickHits
  * @property {number[]} play.hitErrorArray
  * @property {object} play.combo
  * @property {number} play.combo.current
  * @property {number} play.combo.max
  * @property {object} play.mods
+ * @property {string} play.mods.checksum
  * @property {number} play.mods.number
  * @property {string} play.mods.name
+ * @property {object[]} play.mods.array
+ * @property {string} play.mods.array.acronym
+ * @property {object} play.mods.array.settings
+ * @property {number} play.mods.rate
  * @property {object} play.rank
  * @property {string} play.rank.current
  * @property {string} play.rank.maxThisPlay
@@ -745,7 +759,6 @@ export default WebSocketManager;
  * @property {boolean} leaderboard.isFailed
  * @property {number} leaderboard.position
  * @property {number} leaderboard.team
- * @property {number} leaderboard.team
  * @property {string} leaderboard.name
  * @property {number} leaderboard.score
  * @property {number} leaderboard.accuracy
@@ -760,11 +773,21 @@ export default WebSocketManager;
  * @property {number} leaderboard.combo.current
  * @property {number} leaderboard.combo.max
  * @property {object} leaderboard.mods
+ * @property {string} leaderboard.mods.checksum
  * @property {number} leaderboard.mods.number
  * @property {string} leaderboard.mods.name
+ * @property {object[]} leaderboard.mods.array
+ * @property {string} leaderboard.mods.array.acronym
+ * @property {object} leaderboard.mods.array.settings
+ * @property {number} leaderboard.mods.rate
  * @property {string} leaderboard.rank
  * @property {object} performance
  * @property {object} performance.accuracy
+ * @property {number} performance.accuracy.90
+ * @property {number} performance.accuracy.91
+ * @property {number} performance.accuracy.92
+ * @property {number} performance.accuracy.93
+ * @property {number} performance.accuracy.94
  * @property {number} performance.accuracy.95
  * @property {number} performance.accuracy.96
  * @property {number} performance.accuracy.97
@@ -777,6 +800,7 @@ export default WebSocketManager;
  * @property {number[]} performance.graph.series.data
  * @property {number[]} performance.graph.xaxis
  * @property {object} resultsScreen
+ * @property {number} resultsScreen.scoreId
  * @property {string} resultsScreen.playerName
  * @property {object} resultsScreen.mode
  * @property {number} resultsScreen.mode.number
@@ -790,9 +814,16 @@ export default WebSocketManager;
  * @property {number} resultsScreen.hits.300
  * @property {number} resultsScreen.hits.geki
  * @property {number} resultsScreen.hits.katu
+ * @property {number} resultsScreen.hits.sliderEndHits
+ * @property {number} resultsScreen.hits.sliderTickHits
  * @property {object} resultsScreen.mods
+ * @property {string} resultsScreen.mods.checksum
  * @property {number} resultsScreen.mods.number
  * @property {string} resultsScreen.mods.name
+ * @property {object[]} resultsScreen.mods.array
+ * @property {string} resultsScreen.mods.array.acronym
+ * @property {object} resultsScreen.mods.array.settings
+ * @property {number} resultsScreen.mods.rate
  * @property {number} resultsScreen.maxCombo
  * @property {string} resultsScreen.rank
  * @property {object} resultsScreen.pp
@@ -814,9 +845,6 @@ export default WebSocketManager;
  * @property {string} directPath.beatmapAudio
  * @property {string} directPath.beatmapFolder
  * @property {string} directPath.skinFolder
- * @property {string} directPath.collections
- * @property {string} directPath.osudb
- * @property {string} directPath.scoresdb
  * @property {object} tourney
  * @property {boolean} tourney.scoreVisible
  * @property {boolean} tourney.starsVisible
@@ -848,6 +876,44 @@ export default WebSocketManager;
  * @property {number} tourney.clients.user.playCount
  * @property {number} tourney.clients.user.globalRank
  * @property {number} tourney.clients.user.totalPP
+ * @property {object} tourney.clients.beatmap
+ * @property {object} tourney.clients.beatmap.stats
+ * @property {object} tourney.clients.beatmap.stats.stars
+ * @property {number} tourney.clients.beatmap.stats.stars.live
+ * @property {number} tourney.clients.beatmap.stats.stars.aim
+ * @property {number} tourney.clients.beatmap.stats.stars.speed
+ * @property {number} tourney.clients.beatmap.stats.stars.flashlight
+ * @property {number} tourney.clients.beatmap.stats.stars.sliderFactor
+ * @property {number} tourney.clients.beatmap.stats.stars.stamina
+ * @property {number} tourney.clients.beatmap.stats.stars.rhythm
+ * @property {number} tourney.clients.beatmap.stats.stars.color
+ * @property {number} tourney.clients.beatmap.stats.stars.peak
+ * @property {number} tourney.clients.beatmap.stats.stars.hitWindow
+ * @property {number} tourney.clients.beatmap.stats.stars.total
+ * @property {object} tourney.clients.beatmap.stats.ar
+ * @property {number} tourney.clients.beatmap.stats.ar.original
+ * @property {number} tourney.clients.beatmap.stats.ar.converted
+ * @property {object} tourney.clients.beatmap.stats.cs
+ * @property {number} tourney.clients.beatmap.stats.cs.original
+ * @property {number} tourney.clients.beatmap.stats.cs.converted
+ * @property {object} tourney.clients.beatmap.stats.od
+ * @property {number} tourney.clients.beatmap.stats.od.original
+ * @property {number} tourney.clients.beatmap.stats.od.converted
+ * @property {object} tourney.clients.beatmap.stats.hp
+ * @property {number} tourney.clients.beatmap.stats.hp.original
+ * @property {number} tourney.clients.beatmap.stats.hp.converted
+ * @property {object} tourney.clients.beatmap.stats.bpm
+ * @property {number} tourney.clients.beatmap.stats.bpm.realtime
+ * @property {number} tourney.clients.beatmap.stats.bpm.common
+ * @property {number} tourney.clients.beatmap.stats.bpm.min
+ * @property {number} tourney.clients.beatmap.stats.bpm.max
+ * @property {object} tourney.clients.beatmap.stats.objects
+ * @property {number} tourney.clients.beatmap.stats.objects.circles
+ * @property {number} tourney.clients.beatmap.stats.objects.sliders
+ * @property {number} tourney.clients.beatmap.stats.objects.spinners
+ * @property {number} tourney.clients.beatmap.stats.objects.holds
+ * @property {number} tourney.clients.beatmap.stats.objects.total
+ * @property {number} tourney.clients.beatmap.stats.maxCombo
  * @property {object} tourney.clients.play
  * @property {string} tourney.clients.play.playerName
  * @property {object} tourney.clients.play.mode
@@ -866,6 +932,8 @@ export default WebSocketManager;
  * @property {number} tourney.clients.play.hits.geki
  * @property {number} tourney.clients.play.hits.katu
  * @property {number} tourney.clients.play.hits.sliderBreaks
+ * @property {number} tourney.clients.play.hits.sliderEndHits
+ * @property {number} tourney.clients.play.hits.sliderTickHits
  * @property {number[]} tourney.clients.play.hitErrorArray
  * @property {object} tourney.clients.play.mods
  * @property {number} tourney.clients.play.mods.number
@@ -873,6 +941,14 @@ export default WebSocketManager;
  * @property {object} tourney.clients.play.combo
  * @property {number} tourney.clients.play.combo.current
  * @property {number} tourney.clients.play.combo.max
+ * @property {object} tourney.clients.play.mods
+ * @property {string} tourney.clients.play.mods.checksum
+ * @property {number} tourney.clients.play.mods.number
+ * @property {string} tourney.clients.play.mods.name
+ * @property {object[]} tourney.clients.play.mods.array
+ * @property {string} tourney.clients.play.mods.array.acronym
+ * @property {object} play.mods.array.settings
+ * @property {number} tourney.clients.play.mods.rate
  * @property {object} tourney.clients.play.rank
  * @property {string} tourney.clients.play.rank.current
  * @property {string} tourney.clients.play.rank.maxThisPlay

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -527,10 +527,10 @@ export default WebSocketManager;
 
 
 /** @typedef {object} WEBSOCKET_V2
- * @property {string} client
+ * @property {'stable' | 'lazer'} client
  * @property {object} state
- * @property {number} state.number
- * @property {string} state.name
+ * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23} state.number
+ * @property {'menu' | 'edit' | 'play' | 'exit' | 'selectEdit' | 'selectPlay' | 'selectDrawings' | 'resultScreen' | 'update' | 'busy' | 'unknown' | 'lobby' | 'matchSetup' | 'selectMulti' | 'rankingVs' | 'onlineSelection' | 'optionsOffsetWizard' | 'rankingTagCoop' | 'rankingTeam' | 'beatmapImport' | 'packageUpdater' | 'benchmark' | 'tourney' | 'charts'} state.name
  * @property {object} session
  * @property {number} session.playTime
  * @property {number} session.playCount
@@ -538,16 +538,16 @@ export default WebSocketManager;
  * @property {boolean} settings.interfaceVisible
  * @property {boolean} settings.replayUIVisible
  * @property {object} settings.chatVisibilityStatus
- * @property {number} settings.chatVisibilityStatus.number
- * @property {string} settings.chatVisibilityStatus.name
+ * @property {0 | 1 | 2} settings.chatVisibilityStatus.number
+ * @property {'hidden' | 'visible' | 'visibleWithFriendsList'} settings.chatVisibilityStatus.name
  * @property {object} settings.leaderboard
  * @property {boolean} settings.leaderboard.visible
  * @property {object} settings.leaderboard.type
- * @property {number} settings.leaderboard.type.number
- * @property {string} settings.leaderboard.type.name
+ * @property {0 | 1 | 2 | 3 | 4} settings.leaderboard.type.number
+ * @property {'local' | 'global' | 'selectedmods' | 'friends' | 'country'} settings.leaderboard.type.name
  * @property {object} settings.progressBar
- * @property {number} settings.progressBar.number
- * @property {string} settings.progressBar.name
+ * @property {0 | 1 | 2 | 3 | 4} settings.progressBar.number
+ * @property {'off' | 'pie' | 'topRight' | 'bottomRight' | 'bottom'} settings.progressBar.name
  * @property {number} settings.bassDensity
  * @property {object} settings.resolution
  * @property {boolean} settings.resolution.fullscreen
@@ -557,12 +557,12 @@ export default WebSocketManager;
  * @property {number} settings.resolution.heightFullscreen
  * @property {object} settings.client
  * @property {boolean} settings.client.updateAvailable
- * @property {number} settings.client.branch
- * @property {string} settings.client.version
+ * @property {0 | 1 | 2 | 3} settings.client.branch
+ * @property {'cuttingEdge' | 'stable' | 'beta' | 'fallback'} settings.client.version
  * @property {object} settings.scoreMeter
  * @property {object} settings.scoreMeter.type
- * @property {number} settings.scoreMeter.type.number
- * @property {string} settings.scoreMeter.type.name
+ * @property {0 | 1 | 2} settings.scoreMeter.type.number
+ * @property {'none' | 'colour' | 'error'} settings.scoreMeter.type.name
  * @property {number} settings.scoreMeter.size
  * @property {object} settings.cursor
  * @property {boolean} settings.cursor.useSkinCursor
@@ -577,11 +577,11 @@ export default WebSocketManager;
  * @property {boolean} settings.mania.speedBPMScale
  * @property {boolean} settings.mania.usePerBeatmapSpeedScale
  * @property {object} settings.sort
- * @property {number} settings.sort.number
- * @property {string} settings.sort.name
+ * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7} settings.sort.number
+ * @property {'artist' | 'bpm' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'title'} settings.sort.name
  * @property {object} settings.group
- * @property {number} settings.group.number
- * @property {string} settings.group.name
+ * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19} settings.group.number
+ * @property {'none' | 'artist' | 'bPM' | 'creator' | 'date' | 'difficulty' | 'length' | 'rank' | 'myMaps' | 'search' | 'show_All' | 'title' | 'lastPlayed' | 'onlineFavourites' | 'maniaKeys' | 'mode' | 'collection' | 'rankedStatus'} settings.group.name
  * @property {object} settings.skin
  * @property {boolean} settings.skin.useDefaultSkinInEditor
  * @property {boolean} settings.skin.ignoreBeatmapSkins
@@ -589,8 +589,8 @@ export default WebSocketManager;
  * @property {boolean} settings.skin.useTaikoSkin
  * @property {string} settings.skin.name
  * @property {object} settings.mode
- * @property {number} settings.mode.number
- * @property {string} settings.mode.name
+ * @property {0 | 1 | 2 | 3} settings.mode.number
+ * @property {'osu' | 'taiko' | 'fruits' | 'mania'} settings.mode.name
  * @property {object} settings.audio
  * @property {boolean} settings.audio.ignoreBeatmapSounds
  * @property {boolean} settings.audio.useSkinSamples
@@ -621,16 +621,16 @@ export default WebSocketManager;
  * @property {string} settings.keybinds.quickRetry
  * @property {object} profile
  * @property {object} profile.userStatus
- * @property {number} profile.userStatus.number
- * @property {string} profile.userStatus.name
+ * @property {0 | 256 | 257 | 65537 | 65793} profile.userStatus.number
+ * @property {'reconnecting' | 'guest' | 'recieving_data' | 'disconnected' | 'connected'} profile.userStatus.name
  * @property {object} profile.banchoStatus
- * @property {number} profile.banchoStatus.number
- * @property {string} profile.banchoStatus.name
+ * @property {0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13} profile.banchoStatus.number
+ * @property {'idle' | 'afk' | 'playing' | 'editing' | 'modding' | 'multiplayer' | 'watching | 'unknown' | 'testing' | 'submitting' | 'paused' | 'lobby' | 'multiplaying' | 'osuDirect'} profile.banchoStatus.name
  * @property {number} profile.id
  * @property {string} profile.name
  * @property {object} profile.mode
- * @property {number} profile.mode.number
- * @property {string} profile.mode.name
+ * @property {0 | 1 | 2 | 3 } profile.mode.number
+ * @property {'osu' | 'taiko' | 'fruits' | 'mania'} profile.mode.name
  * @property {number} profile.rankedScore
  * @property {number} profile.level
  * @property {number} profile.accuracy
@@ -649,14 +649,14 @@ export default WebSocketManager;
  * @property {number} beatmap.time.lastObject
  * @property {number} beatmap.time.mp3Length
  * @property {object} beatmap.status
- * @property {number} beatmap.status.number
- * @property {string} beatmap.status.name
+ * @property {0 | 1 | 2 | 4 | 5 | 6 | 7} beatmap.status.number
+ * @property {'unknown' | 'notSubmitted' | 'pending' | 'ranked' | 'approved' | 'qualified' | 'loved'} beatmap.status.name
  * @property {string} beatmap.checksum
  * @property {number} beatmap.id
  * @property {number} beatmap.set
  * @property {object} beatmap.mode
- * @property {number} beatmap.mode.number
- * @property {string} beatmap.mode.name
+ * @property {0 | 1 | 2 | 3 } beatmap.mode.number
+ * @property {'osu' | 'taiko' | 'fruits' | 'mania'} beatmap.mode.name
  * @property {string} beatmap.artist
  * @property {string} beatmap.artistUnicode
  * @property {string} beatmap.title
@@ -703,8 +703,8 @@ export default WebSocketManager;
  * @property {object} play
  * @property {string} play.playerName
  * @property {object} play.mode
- * @property {number} play.mode.number
- * @property {string} play.mode.name
+ * @property {0 | 1 | 2 | 3 } play.mode.number
+ * @property {'osu' | 'taiko' | 'fruits' | 'mania'} play.mode.name
  * @property {number} play.score
  * @property {number} play.accuracy
  * @property {object} play.healthBar
@@ -733,8 +733,8 @@ export default WebSocketManager;
  * @property {object} play.mods.array.settings
  * @property {number} play.mods.rate
  * @property {object} play.rank
- * @property {string} play.rank.current
- * @property {string} play.rank.maxThisPlay
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} play.rank.current
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} play.rank.maxThisPlay
  * @property {object} play.pp
  * @property {number} play.pp.current
  * @property {number} play.pp.fc
@@ -780,7 +780,7 @@ export default WebSocketManager;
  * @property {string} leaderboard.mods.array.acronym
  * @property {object} leaderboard.mods.array.settings
  * @property {number} leaderboard.mods.rate
- * @property {string} leaderboard.rank
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} leaderboard.rank
  * @property {object} performance
  * @property {object} performance.accuracy
  * @property {number} performance.accuracy.90
@@ -796,15 +796,15 @@ export default WebSocketManager;
  * @property {number} performance.accuracy.100
  * @property {object} performance.graph
  * @property {object[]} performance.graph.series
- * @property {string} performance.graph.series.name
+ * @property {'aim' | 'aimNoSliders' | 'flashlight' | 'speed' | 'color' | 'rhythm' | 'stamina' | 'movement' | 'strains'} performance.graph.series.name
  * @property {number[]} performance.graph.series.data
  * @property {number[]} performance.graph.xaxis
  * @property {object} resultsScreen
  * @property {number} resultsScreen.scoreId
  * @property {string} resultsScreen.playerName
  * @property {object} resultsScreen.mode
- * @property {number} resultsScreen.mode.number
- * @property {string} resultsScreen.mode.name
+ * @property {0 | 1 | 2 | 3 } resultsScreen.mode.number
+ * @property {'osu' | 'taiko' | 'fruits' | 'mania'} resultsScreen.mode.name
  * @property {number} resultsScreen.score
  * @property {number} resultsScreen.accuracy
  * @property {object} resultsScreen.hits
@@ -825,7 +825,7 @@ export default WebSocketManager;
  * @property {object} resultsScreen.mods.array.settings
  * @property {number} resultsScreen.mods.rate
  * @property {number} resultsScreen.maxCombo
- * @property {string} resultsScreen.rank
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} resultsScreen.rank
  * @property {object} resultsScreen.pp
  * @property {number} resultsScreen.pp.current
  * @property {number} resultsScreen.pp.fc
@@ -866,7 +866,7 @@ export default WebSocketManager;
  * @property {number} tourney.totalScore.right
  * @property {object[]} tourney.clients
  * @property {number} tourney.clients.ipcId
- * @property {string} tourney.clients.team
+ * @property {'left' | 'right'} tourney.clients.team
  * @property {object} tourney.clients.user
  * @property {number} tourney.clients.user.id
  * @property {string} tourney.clients.user.name
@@ -917,8 +917,8 @@ export default WebSocketManager;
  * @property {object} tourney.clients.play
  * @property {string} tourney.clients.play.playerName
  * @property {object} tourney.clients.play.mode
- * @property {number} tourney.clients.play.mode.number
- * @property {string} tourney.clients.play.mode.name
+ * @property {0 | 1 | 2 | 3 } tourney.clients.play.mode.number
+ * @property {'osu' | 'taiko' | 'fruits' | 'mania'} tourney.clients.play.mode.name
  * @property {number} tourney.clients.play.score
  * @property {number} tourney.clients.play.accuracy
  * @property {object} tourney.clients.play.healthBar
@@ -950,8 +950,8 @@ export default WebSocketManager;
  * @property {object} play.mods.array.settings
  * @property {number} tourney.clients.play.mods.rate
  * @property {object} tourney.clients.play.rank
- * @property {string} tourney.clients.play.rank.current
- * @property {string} tourney.clients.play.rank.maxThisPlay
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.clients.play.rank.current
+ * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.clients.play.rank.maxThisPlay
  * @property {object} tourney.clients.play.pp
  * @property {number} tourney.clients.play.pp.current
  * @property {number} tourney.clients.play.pp.fc

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -666,15 +666,15 @@ export default WebSocketManager;
  * @property {object} beatmap.stats
  * @property {object} beatmap.stats.stars
  * @property {number} beatmap.stats.stars.live
- * @property {number} beatmap.stats.stars.aim
- * @property {number} beatmap.stats.stars.speed
- * @property {number} beatmap.stats.stars.flashlight
- * @property {number} beatmap.stats.stars.sliderFactor
- * @property {number} beatmap.stats.stars.stamina
- * @property {number} beatmap.stats.stars.rhythm
- * @property {number} beatmap.stats.stars.color
- * @property {number} beatmap.stats.stars.peak
- * @property {number} beatmap.stats.stars.hitWindow
+ * @property {number} [beatmap.stats.stars.aim]
+ * @property {number} [beatmap.stats.stars.speed]
+ * @property {number} [beatmap.stats.stars.flashlight]
+ * @property {number} [beatmap.stats.stars.sliderFactor]
+ * @property {number} [beatmap.stats.stars.stamina]
+ * @property {number} [beatmap.stats.stars.rhythm]
+ * @property {number} [beatmap.stats.stars.color]
+ * @property {number} [beatmap.stats.stars.peak]
+ * @property {number} [beatmap.stats.stars.hitWindow]
  * @property {number} beatmap.stats.stars.total
  * @property {object} beatmap.stats.ar
  * @property {number} beatmap.stats.ar.original
@@ -730,7 +730,7 @@ export default WebSocketManager;
  * @property {string} play.mods.name
  * @property {object[]} play.mods.array
  * @property {string} play.mods.array.acronym
- * @property {object} play.mods.array.settings
+ * @property {object} [play.mods.array.settings]
  * @property {number} play.mods.rate
  * @property {object} play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} play.rank.current
@@ -822,7 +822,7 @@ export default WebSocketManager;
  * @property {string} resultsScreen.mods.name
  * @property {object[]} resultsScreen.mods.array
  * @property {string} resultsScreen.mods.array.acronym
- * @property {object} resultsScreen.mods.array.settings
+ * @property {object} [resultsScreen.mods.array.settings]
  * @property {number} resultsScreen.mods.rate
  * @property {number} resultsScreen.maxCombo
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} resultsScreen.rank
@@ -880,15 +880,15 @@ export default WebSocketManager;
  * @property {object} tourney.clients.beatmap.stats
  * @property {object} tourney.clients.beatmap.stats.stars
  * @property {number} tourney.clients.beatmap.stats.stars.live
- * @property {number} tourney.clients.beatmap.stats.stars.aim
- * @property {number} tourney.clients.beatmap.stats.stars.speed
- * @property {number} tourney.clients.beatmap.stats.stars.flashlight
- * @property {number} tourney.clients.beatmap.stats.stars.sliderFactor
- * @property {number} tourney.clients.beatmap.stats.stars.stamina
- * @property {number} tourney.clients.beatmap.stats.stars.rhythm
- * @property {number} tourney.clients.beatmap.stats.stars.color
- * @property {number} tourney.clients.beatmap.stats.stars.peak
- * @property {number} tourney.clients.beatmap.stats.stars.hitWindow
+ * @property {number} [tourney.clients.beatmap.stats.stars.aim]
+ * @property {number} [tourney.clients.beatmap.stats.stars.speed]
+ * @property {number} [tourney.clients.beatmap.stats.stars.flashlight]
+ * @property {number} [tourney.clients.beatmap.stats.stars.sliderFactor]
+ * @property {number} [tourney.clients.beatmap.stats.stars.stamina]
+ * @property {number} [tourney.clients.beatmap.stats.stars.rhythm]
+ * @property {number} [tourney.clients.beatmap.stats.stars.color]
+ * @property {number} [tourney.clients.beatmap.stats.stars.peak]
+ * @property {number} [tourney.clients.beatmap.stats.stars.hitWindow]
  * @property {number} tourney.clients.beatmap.stats.stars.total
  * @property {object} tourney.clients.beatmap.stats.ar
  * @property {number} tourney.clients.beatmap.stats.ar.original
@@ -947,7 +947,7 @@ export default WebSocketManager;
  * @property {string} tourney.clients.play.mods.name
  * @property {object[]} tourney.clients.play.mods.array
  * @property {string} tourney.clients.play.mods.array.acronym
- * @property {object} play.mods.array.settings
+ * @property {object} [play.mods.array.settings]
  * @property {number} tourney.clients.play.mods.rate
  * @property {object} tourney.clients.play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.clients.play.rank.current

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -730,7 +730,7 @@ export default WebSocketManager;
  * @property {string} play.mods.name
  * @property {object[]} play.mods.array
  * @property {string} play.mods.array.acronym
- * @property {object} [play.mods.array.settings] This exists only when playing osu!(lazer)
+ * @property {object} [play.mods.array.settings] This exists only when playing osu!(lazer). You must get the settings manually, e.g. from the `/json/v2` response preview
  * @property {number} play.mods.rate
  * @property {object} play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} play.rank.current
@@ -778,7 +778,7 @@ export default WebSocketManager;
  * @property {string} leaderboard.mods.name
  * @property {object[]} leaderboard.mods.array
  * @property {string} leaderboard.mods.array.acronym
- * @property {object} leaderboard.mods.array.settings
+ * @property {object} [leaderboard.mods.array.settings] This exists only when playing osu!(lazer). You must get the settings manually, e.g. from the `/json/v2` response preview
  * @property {number} leaderboard.mods.rate
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} leaderboard.rank
  * @property {object} performance
@@ -822,7 +822,7 @@ export default WebSocketManager;
  * @property {string} resultsScreen.mods.name
  * @property {object[]} resultsScreen.mods.array
  * @property {string} resultsScreen.mods.array.acronym
- * @property {object} [resultsScreen.mods.array.settings] This exists only when playing osu!(lazer)
+ * @property {object} [resultsScreen.mods.array.settings] This exists only when playing osu!(lazer). You must get the settings manually, e.g. from the `/json/v2` response preview
  * @property {number} resultsScreen.mods.rate
  * @property {number} resultsScreen.maxCombo
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} resultsScreen.rank
@@ -944,7 +944,7 @@ export default WebSocketManager;
  * @property {string} tourney.clients.play.mods.name
  * @property {object[]} tourney.clients.play.mods.array
  * @property {string} tourney.clients.play.mods.array.acronym
- * @property {object} [tourney.clients.play.mods.array.settings] This exists only when playing osu!(lazer)
+ * @property {object} [tourney.clients.play.mods.array.settings] This exists only when playing osu!(lazer). You must get the settings manually, e.g. from the `/json/v2` response preview
  * @property {number} tourney.clients.play.mods.rate
  * @property {object} tourney.clients.play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.clients.play.rank.current

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -1,6 +1,6 @@
 class WebSocketManager {
   constructor(host) {
-    this.version = '0.1.2';
+    this.version = '0.1.3';
 
     if (host) {
       this.host = host;

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -947,7 +947,7 @@ export default WebSocketManager;
  * @property {string} tourney.clients.play.mods.name
  * @property {object[]} tourney.clients.play.mods.array
  * @property {string} tourney.clients.play.mods.array.acronym
- * @property {object} [play.mods.array.settings] This exists only when playing osu!(lazer)
+ * @property {object} [tourney.clients.play.mods.array.settings] This exists only when playing osu!(lazer)
  * @property {number} tourney.clients.play.mods.rate
  * @property {object} tourney.clients.play.rank
  * @property {'XH' | 'X' | 'SH' | 'S' | 'A' | 'B' | 'C' | 'D'} tourney.clients.play.rank.current

--- a/quickstart/js/socket.js
+++ b/quickstart/js/socket.js
@@ -282,6 +282,7 @@ export default WebSocketManager;
 
 
 /** @typedef {object} WEBSOCKET_V1
+ * @property {string} client
  * @property {object} settings
  * @property {boolean} settings.showInterface
  * @property {object} settings.folders
@@ -318,6 +319,7 @@ export default WebSocketManager;
  * @property {number} menu.bm.stats.HP
  * @property {number} menu.bm.stats.SR
  * @property {object} menu.bm.stats.BPM
+ * @property {number} menu.bm.stats.BPM.realtime
  * @property {number} menu.bm.stats.BPM.common
  * @property {number} menu.bm.stats.BPM.min
  * @property {number} menu.bm.stats.BPM.max
@@ -341,6 +343,11 @@ export default WebSocketManager;
  * @property {number} menu.mods.num
  * @property {string} menu.mods.str
  * @property {object} menu.pp
+ * @property {number} menu.pp.90
+ * @property {number} menu.pp.91
+ * @property {number} menu.pp.92
+ * @property {number} menu.pp.93
+ * @property {number} menu.pp.94
  * @property {number} menu.pp.95
  * @property {number} menu.pp.96
  * @property {number} menu.pp.97
@@ -411,21 +418,38 @@ export default WebSocketManager;
  * @property {number} gameplay.leaderboard.ourplayer.position
  * @property {number} gameplay.leaderboard.ourplayer.isPassing
  * @property {object[]} gameplay.leaderboard.slots
+ * @property {string} gameplay.leaderboard.slots.name
+ * @property {number} gameplay.leaderboard.slots.score
+ * @property {number} gameplay.leaderboard.slots.combo
+ * @property {number} gameplay.leaderboard.slots.maxCombo
+ * @property {string} gameplay.leaderboard.slots.mods
+ * @property {number} gameplay.leaderboard.slots.h300
+ * @property {number} gameplay.leaderboard.slots.h100
+ * @property {number} gameplay.leaderboard.slots.h50
+ * @property {number} gameplay.leaderboard.slots.h0
+ * @property {number} gameplay.leaderboard.slots.team
+ * @property {number} gameplay.leaderboard.slots.position
+ * @property {number} gameplay.leaderboard.slots.isPassing
  * @property {boolean} gameplay._isReplayUiHidden
  * @property {object} resultsScreen
  * @property {number} resultsScreen.0
  * @property {number} resultsScreen.50
  * @property {number} resultsScreen.100
  * @property {number} resultsScreen.300
+ * @property {number} resultsScreen.mode
  * @property {string} resultsScreen.name
  * @property {number} resultsScreen.score
+ * @property {number} resultsScreen.accuracy
  * @property {number} resultsScreen.maxCombo
  * @property {object} resultsScreen.mods
  * @property {number} resultsScreen.mods.num
  * @property {string} resultsScreen.mods.str
  * @property {number} resultsScreen.geki
  * @property {number} resultsScreen.katu
+ * @property {string} resultsScreen.grade
+ * @property {string} resultsScreen.createdAt
  * @property {object} userProfile
+ * @property {number} userProfile.rawLoginStatus
  * @property {string} userProfile.name
  * @property {number} userProfile.accuracy
  * @property {number} userProfile.rankedScore
@@ -436,7 +460,7 @@ export default WebSocketManager;
  * @property {number} userProfile.rank
  * @property {number} userProfile.countryCode
  * @property {number} userProfile.performancePoints
- * @property {boolean} userProfile.isConnected
+ * @property {number} userProfile.rawBanchoStatus
  * @property {string} userProfile.backgroundColour
  * @property {object} tourney
  * @property {object} tourney.manager
@@ -452,6 +476,10 @@ export default WebSocketManager;
  * @property {boolean} tourney.manager.bools.scoreVisible
  * @property {boolean} tourney.manager.bools.starsVisible
  * @property {object[]} tourney.manager.chat
+ * @property {string} tourney.manager.chat.team
+ * @property {string} tourney.manager.chat.time
+ * @property {string} tourney.manager.chat.name
+ * @property {string} tourney.manager.chat.messageBody
  * @property {object} tourney.manager.gameplay
  * @property {object} tourney.manager.gameplay.score
  * @property {number} tourney.manager.gameplay.score.left


### PR DESCRIPTION
I may have gotten carried away again and changed a few more things than I talked about on Discord ([see discussion](https://discord.com/channels/1056534107330445362/1185957776665628764/1307711611330625556)). The only things that do not have autocompletion are country codes

For good measure:
- [X] sanity check in some editor because apparently I cannot test things properly
- [X] double-verify the `settings.client` object in the `WEBSOCKET_V2` typedef
- [X] double-verify all of the tourney-related objects (I don't have osu!supporter, so I was just looking at whatever is in the tosu codebase)