### PR TITLE
grind-timer: Fix OBS display

### DIFF
--- a/counters/grind-timer by kiwec/index.html
+++ b/counters/grind-timer by kiwec/index.html
@@ -14,9 +14,13 @@
       }
 
       html {
-        background: #000;
         cursor: pointer;
         user-select: none;
+      }
+
+      body {
+        background: #000;
+        margin: 8px !important;
       }
 
       #timer {
@@ -29,11 +33,18 @@
         text-shadow: 0 2px 4px rgba(0,0,0,0.3);
         text-align: right;
         line-height: 0.9;
+
+        /* OBS support */
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
       }
 
       .paused {
         background: linear-gradient(0, var(--paused-start), var(--paused-end)) !important;
         background-clip: text !important;
+        
+        /* OBS support */
+        -webkit-background-clip: text !important;
       }
     </style>
   </head>

--- a/counters/grind-timer by kiwec/metadata.txt
+++ b/counters/grind-timer by kiwec/metadata.txt
@@ -1,6 +1,6 @@
 Usecase: ingame,obs-overlay
 Name: grind-timer
-Version: 1.1
+Version: 1.2
 Author: kiwec
 CompatibleWith: tosu
 Resolution: 500x100


### PR DESCRIPTION
OBS requires CSS prefixes for the text clipping. It also adds some default CSS, which is now also supported (along with bg transparency).